### PR TITLE
fixed info popup icon on sidebar

### DIFF
--- a/app/assets/stylesheets/components/_popup.scss
+++ b/app/assets/stylesheets/components/_popup.scss
@@ -55,7 +55,7 @@
 }
 
 .info {
-  position: absolute;
+  position: fixed;
   bottom: 35px;
   left: 35px;
 


### PR DESCRIPTION
## Description
Changed the info popup to remain fixed on the page to be aligned with the other sidebar items

## Motivation and Context
Info popup icon was moving up and down on scroll, but the sidebar and the rest of its items were fixed on webpage, that fixes it so that info popup icon is fixed like other sidebar items